### PR TITLE
`access_token` arg now defaults to env var on nil argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ ruby starling-export.rb qif --access_token=#{access_token}
 ruby starling-export.rb csv --access_token=#{access_token}
 ```
 
+You may omit the `--access_token=` argument, and use an environmental
+variable - `$STARLING_ACCESS_TOKEN` instead.
+
 ### access_token
 
 You will need to get a token from [here][token_req], with the

--- a/starling-export.rb
+++ b/starling-export.rb
@@ -24,7 +24,10 @@ command :qif do |c|
   c.option '--directory STRING', String, 'The directory to save this file'
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
-    options.default directory: "#{File.dirname(__FILE__)}/tmp"
+    options.default \
+      directory: "#{File.dirname(__FILE__)}/tmp",
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     path = "#{options.directory}/starling.qif"
     Qif::Writer.open(path, type = 'Bank', format = 'dd/mm/yyyy') do |qif|
 
@@ -63,7 +66,10 @@ command :csv do |c|
   c.option '--directory STRING', String, 'The directory to save this file'
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
-    options.default directory: "#{File.dirname(__FILE__)}/tmp"
+    options.default \
+      directory: "#{File.dirname(__FILE__)}/tmp",
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     path = "#{options.directory}/starling.csv"
 
     CSV.open(path, "wb") do |csv|
@@ -101,6 +107,9 @@ command :balance do |c|
   c.summary = ''
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
+    options.default \
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     account_data = account(options.access_token)
     account_info = account_info(options.access_token, account_data['accountUid'])
     balance_data = balance(options.access_token, account_data['accountUid'])


### PR DESCRIPTION
In the event that the `access_token` argument passed to the script is
nil, or not passed, the script will now attempt to get the access token
from the environment variable `$STARLING_ACCESS_TOKEN`.

This commit also updates the README.

Fixes #6.