### PR TITLE
Tweak and tidy up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ruby starling-export.rb qif --access_token=#{access_token}
 ruby starling-export.rb csv --access_token=#{access_token}
 ```
 
-You may omit the `--access_token=` argument, and use an environmental
+You may omit the `--access_token` argument, and use an environmental
 variable - `$STARLING_ACCESS_TOKEN` instead.
 
 ### access_token:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A quick a and simple way to get Starling transactions into QIF and CSV files.
 ```
 ruby starling-export.rb qif --access_token=${access_token}
 ruby starling-export.rb csv --access_token=${access_token}
+ruby starling-export.rb balance --access_token=${access_token}
 ```
 
 You may omit the `--access_token` argument, and use an environmental

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ ruby starling-export.rb qif --access_token=#{access_token}
 ruby starling-export.rb csv --access_token=#{access_token}
 ```
 
+You may omit the `--access_token=` argument, and use an environmental
+variable - `$STARLING_ACCESS_TOKEN` instead.
+
 ### access_token
 
 You will need to get a token from [here][token_req], with the

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A quick a and simple way to get Starling transactions into QIF and CSV files.
 ## How to use:
 
 ```
-ruby starling-export.rb qif --access_token=#{access_token}
-ruby starling-export.rb csv --access_token=#{access_token}
+ruby starling-export.rb qif --access_token=${access_token}
+ruby starling-export.rb csv --access_token=${access_token}
 ```
 
 You may omit the `--access_token` argument, and use an environmental

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A quick a and simple way to get Starling transactions into QIF and CSV files.
 
-
-### How to use:
+## How to use:
 
 ```
 ruby starling-export.rb qif --access_token=#{access_token}
@@ -13,7 +12,7 @@ ruby starling-export.rb csv --access_token=#{access_token}
 You may omit the `--access_token=` argument, and use an environmental
 variable - `$STARLING_ACCESS_TOKEN` instead.
 
-### access_token
+### access_token:
 
 You will need to get a token from [here][token_req], with the
 following scopes:

--- a/starling-export.rb
+++ b/starling-export.rb
@@ -24,7 +24,10 @@ command :qif do |c|
   c.option '--directory STRING', String, 'The directory to save this file'
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
-    options.default directory: "#{File.dirname(__FILE__)}/tmp"
+    options.default \
+      directory: "#{File.dirname(__FILE__)}/tmp",
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     path = "#{options.directory}/starling.qif"
     Qif::Writer.open(path, type = 'Bank', format = 'dd/mm/yyyy') do |qif|
 
@@ -63,7 +66,10 @@ command :csv do |c|
   c.option '--directory STRING', String, 'The directory to save this file'
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
-    options.default directory: "#{File.dirname(__FILE__)}/tmp"
+    options.default \
+      directory: "#{File.dirname(__FILE__)}/tmp",
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     path = "#{options.directory}/starling.csv"
 
     CSV.open(path, "wb") do |csv|
@@ -101,6 +107,9 @@ command :balance do |c|
   c.summary = ''
   c.option '--access_token STRING', String, 'The access_token from Starling'
   c.action do |args, options|
+    options.default \
+      access_token: ENV["STARLING_ACCESS_TOKEN"]
+
     account_data = account(options.access_token)
     account_info = account_info(options.access_token, account_data['accountUid'])
     balance_data = balance(options.access_token, account_data['accountUid'])


### PR DESCRIPTION
Latest PR!

This commit starts from where #8 left off.

- It adjusts the Markdown nesting and headers to help organise the README slightly.

- It removes the `=` from the `--access_token` omission example introduced in 6014653, to avoid confusion and to make it more obvious its a parameter.

- It replaces the Ruby-style variables (`#{}`) to shell-style variables (`${}`) in order to make it consistent with the type of shell a user of this script would typically use. This reduces confusion.

-  I have also added the `balance` subcommand to the README for the script, as it was missing before.

Please feel free to cherry pick commits from here if you wish. I suspect that #8 _will_ need to be merged first, though!